### PR TITLE
Initial scaffolding for schlauDorf Flask application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+venv/
+.env
+*.db
+logs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # schlauDorf
+
+This repository contains the initial scaffold for the **schlauDorf** village application built with Flask.
+
+## Development setup
+
+Run the provided installation script to fetch required system and Python
+dependencies. It creates a virtual environment and installs everything from
+`requirements.txt`.
+
+```bash
+./install.sh
+source venv/bin/activate
+flask --app run.py run
+```
+
+The project is licensed under the MIT License. See [LICENSE](LICENSE) for
+details.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,43 @@
+from flask import Flask
+
+from .config import Config
+from .extensions import db, migrate, login_manager, socketio, csrf
+
+
+def create_app(config_class: type = Config) -> Flask:
+    """Application factory for the schlauDorf project."""
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    # Initialise extensions
+    db.init_app(app)
+    migrate.init_app(app, db)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+    socketio.init_app(app)
+
+    login_manager.login_view = 'auth.login'
+
+    # Register blueprints
+    from .routes.main import bp as main_bp
+    app.register_blueprint(main_bp)
+
+    from .routes.auth import bp as auth_bp
+    app.register_blueprint(auth_bp)
+
+    from .routes.news import bp as news_bp
+    app.register_blueprint(news_bp)
+
+    from .routes.chat import bp as chat_bp
+    app.register_blueprint(chat_bp)
+
+    from .routes.maps import bp as maps_bp
+    app.register_blueprint(maps_bp)
+
+    from .routes.gpx import bp as gpx_bp
+    app.register_blueprint(gpx_bp)
+
+    from .routes.admin import bp as admin_bp
+    app.register_blueprint(admin_bp)
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,31 @@
+"""Application configuration module for schlauDorf.
+
+This file exposes the :class:`Config` class used by the application factory
+and tests. Configuration values are primarily sourced from environment
+variables loaded via ``python-dotenv`` to simplify local development.
+"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    """Base configuration loaded from environment variables."""
+
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
+    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL", "sqlite:///dev.db")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "app/static/uploads")
+    MAX_CONTENT_LENGTH = int(os.environ.get("MAX_CONTENT_LENGTH", 52428800))
+
+    WMS_BASE_URL = os.environ.get("WMS_BASE_URL")
+    WMS_LAYERS = {
+        "luftbild": "rlp_luftbild",
+        "topographie": "rlp_dtk",
+        "liegenschaft": "rlp_alk",
+    }
+
+    ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL", "admin@example.com")
+    ADMIN_NAME = "Jonas Hellinghausen"

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,13 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+from flask_login import LoginManager
+from flask_socketio import SocketIO
+from flask_wtf.csrf import CSRFProtect
+
+# Initialize extensions without app for factory pattern
+
+db = SQLAlchemy()
+migrate = Migrate()
+login_manager = LoginManager()
+socketio = SocketIO(cors_allowed_origins="*")
+csrf = CSRFProtect()

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,19 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField
+from wtforms.validators import DataRequired, Email, EqualTo
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    submit = SubmitField('Login')
+
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    email = StringField('Email', validators=[DataRequired(), Email()])
+    first_name = StringField('First name', validators=[DataRequired()])
+    last_name = StringField('Last name', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    password2 = PasswordField('Confirm password', validators=[DataRequired(), EqualTo('password')])
+    submit = SubmitField('Register')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,11 @@
+"""Database models for the schlauDorf application."""
+
+from .user import User
+from .news import News
+from .chat import ChatRoom, ChatMessage
+from .event import Event
+from .gpx import GPXTrack
+
+__all__ = [
+    'User', 'News', 'ChatRoom', 'ChatMessage', 'Event', 'GPXTrack'
+]

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from ..extensions import db
+
+
+class ChatRoom(db.Model):
+    __tablename__ = 'chat_rooms'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    description = db.Column(db.Text)
+    is_public = db.Column(db.Boolean, default=True)
+    created_by = db.Column(db.Integer, db.ForeignKey('users.id'))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    messages = db.relationship('ChatMessage', backref='room', cascade='all, delete-orphan', lazy=True)
+
+    def __repr__(self):  # pragma: no cover
+        return f'<ChatRoom {self.name}>'
+
+
+class ChatMessage(db.Model):
+    __tablename__ = 'chat_messages'
+
+    id = db.Column(db.Integer, primary_key=True)
+    room_id = db.Column(db.Integer, db.ForeignKey('chat_rooms.id', ondelete='CASCADE'))
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    message = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):  # pragma: no cover
+        return f'<ChatMessage {self.id}>'

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from ..extensions import db
+
+
+class Event(db.Model):
+    __tablename__ = 'events'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    start_date = db.Column(db.DateTime, nullable=False)
+    end_date = db.Column(db.DateTime)
+    location = db.Column(db.String(200))
+    location_lat = db.Column(db.Numeric(10, 8))
+    location_lng = db.Column(db.Numeric(11, 8))
+    organizer_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    max_participants = db.Column(db.Integer)
+    is_public = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):  # pragma: no cover
+        return f'<Event {self.title}>'

--- a/app/models/gpx.py
+++ b/app/models/gpx.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from geoalchemy2 import Geometry
+
+from ..extensions import db
+
+
+class GPXTrack(db.Model):
+    __tablename__ = 'gpx_tracks'
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text)
+    filename = db.Column(db.String(255), nullable=False)
+    track_data = db.Column(Geometry('LINESTRING', srid=4326))
+    distance_km = db.Column(db.Numeric(8, 3))
+    elevation_gain_m = db.Column(db.Integer)
+    uploaded_by = db.Column(db.Integer, db.ForeignKey('users.id'))
+    is_public = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):  # pragma: no cover
+        return f'<GPXTrack {self.name}>'

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from ..extensions import db
+
+
+class News(db.Model):
+    __tablename__ = 'news'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    author_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    is_published = db.Column(db.Boolean, default=False)
+    is_pinned = db.Column(db.Boolean, default=False)
+    image_filename = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self):  # pragma: no cover
+        return f'<News {self.title}>'

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_login import UserMixin
+
+from ..extensions import db, login_manager
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = 'users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(200), nullable=False)
+    first_name = db.Column(db.String(50), nullable=False)
+    last_name = db.Column(db.String(50), nullable=False)
+    phone = db.Column(db.String(20))
+    address = db.Column(db.Text)
+    is_verified = db.Column(db.Boolean, default=False)
+    is_admin = db.Column(db.Boolean, default=False)
+    avatar_filename = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    last_login = db.Column(db.DateTime)
+
+    news = db.relationship('News', backref='author', lazy=True)
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
+
+    def __repr__(self) -> str:  # pragma: no cover - repr is trivial
+        return f'<User {self.username}>'
+
+
+@login_manager.user_loader
+def load_user(user_id: str):
+    return User.query.get(int(user_id))

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Blueprint registration lives in the application factory."""

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, render_template
+from flask_login import login_required
+
+bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+
+@bp.route('/')
+@login_required
+def dashboard():
+    return render_template('admin/dashboard.html')

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, render_template, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required
+
+from ..extensions import db
+from ..forms import LoginForm, RegistrationForm
+from ..models import User
+
+bp = Blueprint('auth', __name__, url_prefix='/auth')
+
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user and user.check_password(form.password.data):
+            login_user(user)
+            return redirect(url_for('main.index'))
+        flash('Invalid credentials', 'danger')
+    return render_template('login.html', form=form)
+
+
+@bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('main.index'))
+
+
+@bp.route('/register', methods=['GET', 'POST'])
+def register():
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        user = User(
+            username=form.username.data,
+            email=form.email.data,
+            first_name=form.first_name.data,
+            last_name=form.last_name.data,
+        )
+        user.set_password(form.password.data)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registration successful - awaiting verification', 'success')
+        return redirect(url_for('auth.login'))
+    return render_template('register.html', form=form)

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, jsonify
+
+from ..models import ChatRoom
+
+bp = Blueprint('chat', __name__, url_prefix='/api/chat')
+
+
+@bp.get('/rooms')
+def list_rooms():
+    rooms = ChatRoom.query.all()
+    return jsonify([{'id': r.id, 'name': r.name} for r in rooms])

--- a/app/routes/gpx.py
+++ b/app/routes/gpx.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, jsonify
+
+from ..models import GPXTrack
+
+bp = Blueprint('gpx', __name__, url_prefix='/api/gpx')
+
+
+@bp.get('/tracks')
+def list_tracks():
+    tracks = GPXTrack.query.filter_by(is_public=True).all()
+    return jsonify([{'id': t.id, 'name': t.name} for t in tracks])

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, render_template
+
+bp = Blueprint('main', __name__)
+
+
+@bp.route('/')
+def index():
+    return render_template('index.html')

--- a/app/routes/maps.py
+++ b/app/routes/maps.py
@@ -1,0 +1,15 @@
+import requests
+from flask import Blueprint, Response, current_app, request
+
+bp = Blueprint('maps', __name__, url_prefix='/api')
+
+
+@bp.route('/wms-proxy')
+def wms_proxy():
+    base_url = current_app.config.get('WMS_BASE_URL')
+    params = request.args.to_dict()
+    params.setdefault('SERVICE', 'WMS')
+    params.setdefault('VERSION', '1.3.0')
+    params.setdefault('REQUEST', 'GetMap')
+    response = requests.get(base_url, params=params)
+    return Response(response.content, content_type=response.headers.get('content-type'))

--- a/app/routes/news.py
+++ b/app/routes/news.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, jsonify
+
+from ..models import News
+
+bp = Blueprint('news', __name__, url_prefix='/api/news')
+
+
+@bp.get('/')
+def list_news():
+    """Return published news items as JSON."""
+    items = News.query.filter_by(is_published=True).all()
+    return jsonify([
+        {
+            'id': item.id,
+            'title': item.title,
+            'content': item.content,
+        }
+        for item in items
+    ])

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container"><h1>Admin Dashboard</h1></div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>schlauDorf</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/">schlauDorf</a>
+      </div>
+    </nav>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="container mt-3">
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,4 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container"><h1>Welcome to schlauDorf</h1></div>
+{% endblock %}

--- a/app/templates/legal/datenschutz.html
+++ b/app/templates/legal/datenschutz.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-5">
+    <h1>Datenschutzerklärung</h1>
+    <h2>1. Datenschutz auf einen Blick</h2>
+    <p>Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit Ihren personenbezogenen Daten passiert, wenn Sie diese Website besuchen.</p>
+    <h2>2. Allgemeine Hinweise und Pflichtinformationen</h2>
+    <p>Der Betreiber dieser Seiten nimmt den Schutz Ihrer persönlichen Daten sehr ernst.</p>
+</div>
+{% endblock %}

--- a/app/templates/legal/impressum.html
+++ b/app/templates/legal/impressum.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-5">
+    <h1>Impressum</h1>
+    <h3>Angaben gemäß § 5 TMG</h3>
+    <p>Jonas Hellinghausen<br>Oberbergstraße 31<br>57520 Molzhain</p>
+    <h3>Kontakt</h3>
+    <p>E-Mail: jonashellinghausen5@gmail.com</p>
+    <h3>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h3>
+    <p>Jonas Hellinghausen<br>Oberbergstraße 31<br>57520 Molzhain</p>
+</div>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container">
+  <h2>Login</h2>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.username.label }} {{ form.username(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.password.label }} {{ form.password(class_='form-control') }}</div>
+    {{ form.submit(class_='btn btn-primary') }}
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container">
+  <h2>Register</h2>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.username.label }} {{ form.username(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.email.label }} {{ form.email(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.first_name.label }} {{ form.first_name(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.last_name.label }} {{ form.last_name(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.password.label }} {{ form.password(class_='form-control') }}</div>
+    <div class="mb-3">{{ form.password2.label }} {{ form.password2(class_='form-control') }}</div>
+    {{ form.submit(class_='btn btn-primary') }}
+  </form>
+</div>
+{% endblock %}

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,12 @@
+bind = "127.0.0.1:8000"
+workers = 2
+worker_class = "gevent"
+worker_connections = 1000
+timeout = 30
+keepalive = 2
+max_requests = 1000
+max_requests_jitter = 100
+preload_app = True
+accesslog = "-"
+errorlog = "-"
+loglevel = "info"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# Optional system dependencies using apt
+if command -v apt-get >/dev/null 2>&1; then
+  echo "Installing system packages..."
+  PKG_CMD="apt-get"
+  if command -v sudo >/dev/null 2>&1 && [ "$(id -u)" -ne 0 ]; then
+    PKG_CMD="sudo apt-get"
+  fi
+  $PKG_CMD update
+  $PKG_CMD install -y python3 python3-venv python3-dev build-essential libpq-dev libgdal-dev
+fi
+
+# Python virtual environment and dependencies
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Environment setup complete. Activate with: source venv/bin/activate"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    root /var/www/vhosts/huemmerstein.de/molzheimat.de/app/static;
+
+    location /static/ {
+        alias /var/www/vhosts/huemmerstein.de/molzheimat.de/app/static/;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location /uploads/ {
+        alias /var/www/vhosts/huemmerstein.de/molzheimat.de/app/static/uploads/;
+        expires 1y;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /socket.io/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    client_max_body_size 50M;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+Flask==2.3.3
+Flask-SQLAlchemy==3.0.5
+Flask-Migrate==4.0.5
+Flask-Login==0.6.3
+Flask-WTF==1.1.1
+Flask-SocketIO==5.3.6
+WTForms==3.0.1
+Werkzeug==2.3.7
+Gunicorn==21.2.0
+psycopg2-binary==2.9.7
+GeoAlchemy2==0.14.1
+Shapely==2.0.1
+gpxpy==1.5.0
+Pillow==10.0.1
+python-dotenv==1.0.0
+requests==2.31.0

--- a/run.py
+++ b/run.py
@@ -1,0 +1,7 @@
+from app import create_app
+from app.extensions import socketio
+
+app = create_app()
+
+if __name__ == '__main__':
+    socketio.run(app, debug=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,42 @@
+import unittest
+
+from app import create_app
+from app.extensions import db
+from app.models import User
+from app.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    WTF_CSRF_ENABLED = False
+
+
+class UserModelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(TestConfig)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_user_creation(self):
+        user = User(
+            username='testuser',
+            email='test@example.com',
+            first_name='Test',
+            last_name='User'
+        )
+        user.set_password('testpassword')
+        db.session.add(user)
+        db.session.commit()
+        self.assertTrue(user.check_password('testpassword'))
+        self.assertEqual(user.username, 'testuser')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- set up Flask application factory and extension registration
- add SQLAlchemy models for users, news, chat rooms, events and GPX tracks
- provide example REST blueprints and templates including legal pages
- add basic unit test and project configuration files
- include install script, MIT license and gitignore updates for GitHub friendliness
- consolidate configuration inside the app package and update tests accordingly

## Testing
- `python -m pip install -r requirements.txt` *(failed: Could not connect to proxy, 403 Forbidden)*
- `python -m pytest` *(failed: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c7d46a24f483208746f663955cd422