### PR TITLE
Add Leaflet map route and assets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+
+def create_app():
+    app = Flask(__name__)
+
+    from .routes import bp
+    app.register_blueprint(bp)
+
+    return app

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint('main', __name__)
+
+from . import maps  # noqa: F401

--- a/app/routes/maps.py
+++ b/app/routes/maps.py
@@ -1,0 +1,9 @@
+from flask import render_template
+
+from . import bp
+
+
+@bp.route('/maps')
+def maps_index():
+    """Render the map view."""
+    return render_template('maps/index.html')

--- a/app/static/css/maps.css
+++ b/app/static/css/maps.css
@@ -1,0 +1,4 @@
+#map {
+  height: 600px;
+  width: 100%;
+}

--- a/app/static/js/maps.js
+++ b/app/static/js/maps.js
@@ -1,0 +1,17 @@
+// Initialize Leaflet map with WMS layer via /api/wms-proxy
+
+document.addEventListener('DOMContentLoaded', function () {
+  const map = L.map('map').setView([0, 0], 2);
+
+  // Base layer from OpenStreetMap
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  // Example WMS layer fetched through the proxy
+  L.tileLayer.wms('/api/wms-proxy', {
+    layers: 'example',
+    format: 'image/png',
+    transparent: true
+  }).addTo(map);
+});

--- a/app/templates/maps/index.html
+++ b/app/templates/maps/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Map View</title>
+    <link
+        rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-o9N1jJyz+y6N0vPd/7nP3yR/4k+xI1NmedEy9hxeu94="
+        crossorigin=""
+    />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/maps.css') }}" />
+</head>
+<body>
+    <div id="map"></div>
+    <script
+        src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-pEjM6XV50Tz3TKH1oWh05rq6ArtyTcwxH8333d3SOkc="
+        crossorigin=""
+    ></script>
+    <script src="{{ url_for('static', filename='js/maps.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Leaflet map template and static JS/CSS assets
- expose `/maps` route to render map with WMS proxy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7da42fddc832091655be8a3ab42d4