### PR TITLE
Add page model with admin CRUD and public display

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,23 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    db.init_app(app)
+
+    from .routes.admin import admin_bp
+    from .routes.pages import pages_bp
+    app.register_blueprint(admin_bp, url_prefix='/admin')
+    app.register_blueprint(pages_bp)
+
+    with app.app_context():
+        db.create_all()
+
+    return app

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .page import Page
+
+__all__ = ["Page"]

--- a/app/models/page.py
+++ b/app/models/page.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from .. import db
+
+
+class Page(db.Model):
+    __tablename__ = 'pages'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    slug = db.Column(db.String(255), unique=True, nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self) -> str:
+        return f"<Page {self.slug}>"

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,1 @@
+# Blueprint registrations live in individual modules.

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+
+from .. import db
+from ..models import Page
+
+
+admin_bp = Blueprint('admin', __name__)
+
+
+@admin_bp.route('/pages')
+def list_pages():
+    pages = Page.query.all()
+    return render_template('admin/pages/index.html', pages=pages)
+
+
+@admin_bp.route('/pages/new', methods=['GET', 'POST'])
+def create_page():
+    if request.method == 'POST':
+        title = request.form['title']
+        slug = request.form['slug']
+        content = request.form['content']
+        page = Page(title=title, slug=slug, content=content)
+        db.session.add(page)
+        db.session.commit()
+        return redirect(url_for('admin.list_pages'))
+    return render_template('admin/pages/create.html')
+
+
+@admin_bp.route('/pages/<int:page_id>/edit', methods=['GET', 'POST'])
+def edit_page(page_id):
+    page = Page.query.get_or_404(page_id)
+    if request.method == 'POST':
+        page.title = request.form['title']
+        page.slug = request.form['slug']
+        page.content = request.form['content']
+        db.session.commit()
+        return redirect(url_for('admin.list_pages'))
+    return render_template('admin/pages/edit.html', page=page)
+
+
+@admin_bp.route('/pages/<int:page_id>/delete', methods=['POST'])
+def delete_page(page_id):
+    page = Page.query.get_or_404(page_id)
+    db.session.delete(page)
+    db.session.commit()
+    return redirect(url_for('admin.list_pages'))

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, render_template
+
+from ..models import Page
+
+
+pages_bp = Blueprint('pages', __name__)
+
+
+@pages_bp.route('/pages/<slug>')
+def show_page(slug: str):
+    page = Page.query.filter_by(slug=slug).first_or_404()
+    return render_template('pages/show.html', page=page)

--- a/app/templates/admin/pages/create.html
+++ b/app/templates/admin/pages/create.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Create Page</title>
+<h1>Create Page</h1>
+<form method="post">
+  <p>Title: <input type="text" name="title"></p>
+  <p>Slug: <input type="text" name="slug"></p>
+  <p>Content:</p>
+  <textarea name="content"></textarea>
+  <p><button type="submit">Create</button></p>
+</form>

--- a/app/templates/admin/pages/edit.html
+++ b/app/templates/admin/pages/edit.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Edit Page</title>
+<h1>Edit Page</h1>
+<form method="post">
+  <p>Title: <input type="text" name="title" value="{{ page.title }}"></p>
+  <p>Slug: <input type="text" name="slug" value="{{ page.slug }}"></p>
+  <p>Content:</p>
+  <textarea name="content">{{ page.content }}</textarea>
+  <p><button type="submit">Save</button></p>
+</form>

--- a/app/templates/admin/pages/index.html
+++ b/app/templates/admin/pages/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Pages</title>
+<h1>Pages</h1>
+<a href="{{ url_for('admin.create_page') }}">Create new page</a>
+<ul>
+  {% for page in pages %}
+    <li>
+      {{ page.title }} -
+      <a href="{{ url_for('admin.edit_page', page_id=page.id) }}">Edit</a>
+      <form action="{{ url_for('admin.delete_page', page_id=page.id) }}" method="post" style="display:inline;">
+        <button type="submit">Delete</button>
+      </form>
+    </li>
+  {% endfor %}
+</ul>

--- a/app/templates/pages/show.html
+++ b/app/templates/pages/show.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>{{ page.title }}</title>
+<h1>{{ page.title }}</h1>
+<div>{{ page.content|safe }}</div>


### PR DESCRIPTION
## Summary
- add SQLAlchemy Page model
- implement admin blueprint with CRUD for pages and simple templates
- expose public /pages/<slug> route to render page content

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7da435ca4832088265da2012d1972