### PR TITLE
feat: add user roles and verification workflow

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,11 +1,11 @@
 """Database models for the schlauDorf application."""
 
-from .user import User
+from .user import User, Role
 from .news import News
 from .chat import ChatRoom, ChatMessage
 from .event import Event
 from .gpx import GPXTrack
 
 __all__ = [
-    'User', 'News', 'ChatRoom', 'ChatMessage', 'Event', 'GPXTrack'
+    'User', 'Role', 'News', 'ChatRoom', 'ChatMessage', 'Event', 'GPXTrack'
 ]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,12 +1,21 @@
 from datetime import datetime
+import enum
+
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_login import UserMixin
 
 from ..extensions import db, login_manager
 
 
+class Role(enum.Enum):
+    """Enumeration of possible user roles."""
+
+    USER = "user"
+    ADMIN = "admin"
+
+
 class User(UserMixin, db.Model):
-    __tablename__ = 'users'
+    __tablename__ = "users"
 
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
@@ -17,7 +26,8 @@ class User(UserMixin, db.Model):
     phone = db.Column(db.String(20))
     address = db.Column(db.Text)
     is_verified = db.Column(db.Boolean, default=False)
-    is_admin = db.Column(db.Boolean, default=False)
+    verification_token = db.Column(db.String(120), unique=True, nullable=True)
+    role = db.Column(db.Enum(Role), default=Role.USER, nullable=False)
     avatar_filename = db.Column(db.String(255))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     last_login = db.Column(db.DateTime)

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,10 +1,70 @@
-from flask import Blueprint, render_template
-from flask_login import login_required
+"""Admin routes for managing users and roles."""
 
-bp = Blueprint('admin', __name__, url_prefix='/admin')
+from functools import wraps
+
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    url_for,
+)
+from flask_login import current_user, login_required
+
+from ..extensions import db
+from ..models import Role, User
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
-@bp.route('/')
+def admin_required(view):
+    """Decorator ensuring the current user has admin privileges."""
+
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not current_user.is_authenticated or current_user.role != Role.ADMIN:
+            abort(403)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+@bp.route("/")
 @login_required
+@admin_required
 def dashboard():
-    return render_template('admin/dashboard.html')
+    """Display a simple dashboard with user management options."""
+
+    users = User.query.all()
+    return render_template("admin/dashboard.html", users=users, roles=list(Role))
+
+
+@bp.route("/users/<int:user_id>/verify")
+@login_required
+@admin_required
+def verify_user(user_id: int):
+    """Mark a user account as verified."""
+
+    user = User.query.get_or_404(user_id)
+    user.is_verified = True
+    db.session.commit()
+    flash("User verified", "success")
+    return redirect(url_for("admin.dashboard"))
+
+
+@bp.route("/users/<int:user_id>/role/<role>")
+@login_required
+@admin_required
+def set_role(user_id: int, role: str):
+    """Change the role for a given user."""
+
+    user = User.query.get_or_404(user_id)
+    try:
+        user.role = Role(role)
+    except ValueError:
+        abort(404)
+    db.session.commit()
+    flash("Role updated", "success")
+    return redirect(url_for("admin.dashboard"))
+

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,11 +1,42 @@
-from flask import Blueprint, render_template, redirect, url_for, flash
+import secrets
+import smtplib
+from email.mime.text import MIMEText
+
+from flask import Blueprint, render_template, redirect, url_for, flash, current_app
 from flask_login import login_user, logout_user, login_required
 
 from ..extensions import db
 from ..forms import LoginForm, RegistrationForm
 from ..models import User
 
-bp = Blueprint('auth', __name__, url_prefix='/auth')
+bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+
+def send_verification_email(user: User) -> None:
+    """Send a verification email to the user.
+
+    The function attempts to deliver an email containing a verification
+    link. Errors during the process are logged but do not interrupt the
+    registration flow.
+    """
+
+    verify_url = url_for("auth.verify", token=user.verification_token, _external=True)
+    msg = MIMEText(f"Please verify your account by visiting: {verify_url}")
+    msg["Subject"] = "Verify your account"
+    msg["From"] = current_app.config.get("ADMIN_EMAIL", "admin@example.com")
+    msg["To"] = user.email
+
+    server = current_app.config.get("MAIL_SERVER", "localhost")
+    port = int(current_app.config.get("MAIL_PORT", 25))
+    username = current_app.config.get("MAIL_USERNAME")
+    password = current_app.config.get("MAIL_PASSWORD")
+    try:
+        with smtplib.SMTP(server, port) as smtp:
+            if username and password:
+                smtp.login(username, password)
+            smtp.send_message(msg)
+    except Exception as exc:  # pragma: no cover - best effort logging
+        current_app.logger.error("Failed to send verification email: %s", exc)
 
 
 @bp.route('/login', methods=['GET', 'POST'])
@@ -14,9 +45,13 @@ def login():
     if form.validate_on_submit():
         user = User.query.filter_by(username=form.username.data).first()
         if user and user.check_password(form.password.data):
-            login_user(user)
-            return redirect(url_for('main.index'))
-        flash('Invalid credentials', 'danger')
+            if not user.is_verified:
+                flash('Account not verified', 'warning')
+            else:
+                login_user(user)
+                return redirect(url_for('main.index'))
+        else:
+            flash('Invalid credentials', 'danger')
     return render_template('login.html', form=form)
 
 
@@ -38,8 +73,22 @@ def register():
             last_name=form.last_name.data,
         )
         user.set_password(form.password.data)
+        user.verification_token = secrets.token_urlsafe(16)
         db.session.add(user)
         db.session.commit()
-        flash('Registration successful - awaiting verification', 'success')
+        send_verification_email(user)
+        flash('Registration successful - please verify via email', 'success')
         return redirect(url_for('auth.login'))
     return render_template('register.html', form=form)
+
+
+@bp.route('/verify/<token>')
+def verify(token: str):
+    """Verify a user's account via the provided token."""
+
+    user = User.query.filter_by(verification_token=token).first_or_404()
+    user.is_verified = True
+    user.verification_token = None
+    db.session.commit()
+    flash('Account verified, you may log in', 'success')
+    return redirect(url_for('auth.login'))

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,4 +1,40 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container"><h1>Admin Dashboard</h1></div>
+<div class="container">
+  <h1>Admin Dashboard</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Username</th>
+        <th>Email</th>
+        <th>Verified</th>
+        <th>Role</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for user in users %}
+      <tr>
+        <td>{{ user.username }}</td>
+        <td>{{ user.email }}</td>
+        <td>{{ 'Yes' if user.is_verified else 'No' }}</td>
+        <td>
+          <span class="badge bg-primary">{{ user.role.value }}</span>
+        </td>
+        <td>
+          {% if not user.is_verified %}
+            <a href="{{ url_for('admin.verify_user', user_id=user.id) }}" class="btn btn-sm btn-success">Verify</a>
+          {% endif %}
+          {% for role in roles %}
+            {% if user.role != role %}
+              <a href="{{ url_for('admin.set_role', user_id=user.id, role=role.value) }}" class="btn btn-sm btn-secondary">{{ role.value }}</a>
+            {% endif %}
+          {% endfor %}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- add role enum and verification token to `User`
- send email with token and add `/auth/verify/<token>` route
- extend admin dashboard for account verification and role management

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.3)*
- `PYTHONPATH=. pytest tests/test_models.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e7227dd083209ec2c98dbafab2d4