### PR TITLE
Add chat message persistence and Socket.IO support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,4 +40,7 @@ def create_app(config_class: type = Config) -> Flask:
     from .routes.api import bp as api_bp
     app.register_blueprint(api_bp)
 
+    # Import Socket.IO event handlers
+    from . import socket_events  # noqa: F401
+
     return app

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -1,6 +1,7 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
-from ..models import ChatRoom
+from ..extensions import db
+from ..models import ChatRoom, ChatMessage
 
 bp = Blueprint('chat', __name__, url_prefix='/api/chat')
 
@@ -9,3 +10,46 @@ bp = Blueprint('chat', __name__, url_prefix='/api/chat')
 def list_rooms():
     rooms = ChatRoom.query.all()
     return jsonify([{'id': r.id, 'name': r.name} for r in rooms])
+
+
+@bp.get('/rooms/<int:room_id>/messages')
+def get_messages(room_id: int):
+    messages = (
+        ChatMessage.query.filter_by(room_id=room_id)
+        .order_by(ChatMessage.created_at)
+        .all()
+    )
+    return jsonify([
+        {
+            'id': m.id,
+            'user_id': m.user_id,
+            'message': m.message,
+            'created_at': m.created_at.isoformat(),
+        }
+        for m in messages
+    ])
+
+
+@bp.post('/rooms/<int:room_id>/messages')
+def post_message(room_id: int):
+    data = request.get_json() or {}
+    message = data.get('message')
+    user_id = data.get('user_id')
+    if not message or user_id is None:
+        return jsonify({'error': 'Invalid payload'}), 400
+
+    chat_message = ChatMessage(room_id=room_id, user_id=user_id, message=message)
+    db.session.add(chat_message)
+    db.session.commit()
+
+    return (
+        jsonify(
+            {
+                'id': chat_message.id,
+                'user_id': chat_message.user_id,
+                'message': chat_message.message,
+                'created_at': chat_message.created_at.isoformat(),
+            }
+        ),
+        201,
+    )

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -6,3 +6,8 @@ bp = Blueprint('main', __name__)
 @bp.route('/')
 def index():
     return render_template('index.html')
+
+
+@bp.route('/chat/rooms/<int:room_id>')
+def chat_room(room_id: int):
+    return render_template('chat/room.html', room_id=room_id)

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -1,0 +1,29 @@
+from flask_socketio import join_room as socket_join_room, emit
+from .extensions import socketio, db
+from .models import ChatMessage
+
+
+@socketio.on('join_room')
+def handle_join_room(data):
+    room = data.get('room')
+    if room is not None:
+        socket_join_room(room)
+
+
+@socketio.on('send_message')
+def handle_send_message(data):
+    room_id = data.get('room_id')
+    user_id = data.get('user_id')
+    message = data.get('message')
+    if None in (room_id, user_id, message):
+        return
+    chat_message = ChatMessage(room_id=room_id, user_id=user_id, message=message)
+    db.session.add(chat_message)
+    db.session.commit()
+    emit('receive_message', {
+        'id': chat_message.id,
+        'room_id': room_id,
+        'user_id': user_id,
+        'message': message,
+        'created_at': chat_message.created_at.isoformat()
+    }, room=room_id)

--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Chat Room {{ room_id }}</h2>
+  <ul id="messages"></ul>
+  <form id="chat-form" class="mt-3">
+    <div class="input-group">
+      <input id="message-input" autocomplete="off" class="form-control" />
+      <button class="btn btn-primary" type="submit">Send</button>
+    </div>
+  </form>
+</div>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
+<script>
+  const roomId = {{ room_id }};
+  const socket = io();
+  socket.emit('join_room', {room: roomId});
+
+  function addMessage(text) {
+    const li = document.createElement('li');
+    li.textContent = text;
+    document.getElementById('messages').appendChild(li);
+  }
+
+  fetch(`/api/chat/rooms/${roomId}/messages`).then(r => r.json()).then(data => {
+    data.forEach(m => addMessage(m.message));
+  });
+
+  socket.on('receive_message', function(msg) {
+    if (msg.room_id === roomId) {
+      addMessage(msg.message);
+    }
+  });
+
+  document.getElementById('chat-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const text = document.getElementById('message-input').value;
+    if (text) {
+      socket.emit('send_message', {room_id: roomId, user_id: 1, message: text});
+      document.getElementById('message-input').value = '';
+    }
+  });
+</script>
+{% endblock %}

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,57 @@
+import unittest
+
+from app import create_app
+from app.extensions import db
+from app.models import User, ChatRoom
+from app.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    WTF_CSRF_ENABLED = False
+
+
+class ChatAPITestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(TestConfig)
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        db.create_all()
+        self.client = self.app.test_client()
+
+        user = User(
+            username='tester',
+            email='tester@example.com',
+            first_name='Test',
+            last_name='User'
+        )
+        user.set_password('password')
+        db.session.add(user)
+        room = ChatRoom(name='Room 1')
+        db.session.add(room)
+        db.session.commit()
+        self.user = user
+        self.room = room
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_post_and_get_messages(self):
+        url = f'/api/chat/rooms/{self.room.id}/messages'
+        response = self.client.post(url, json={'user_id': self.user.id, 'message': 'Hello'})
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data['message'], 'Hello')
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['message'], 'Hello')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Persist chat messages and broadcast with Socket.IO handlers
- Add REST endpoints for room messages and a simple chat room template
- Register new frontend route and cover message API with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c7eac8440883208d30ebf8864c3b48