### PR TITLE
Add legal routes for impressum and privacy pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,6 +22,9 @@ def create_app(config_class: type = Config) -> Flask:
     from .routes.main import bp as main_bp
     app.register_blueprint(main_bp)
 
+    from .routes.legal import bp as legal_bp
+    app.register_blueprint(legal_bp)
+
     from .routes.auth import bp as auth_bp
     app.register_blueprint(auth_bp)
 

--- a/app/routes/legal.py
+++ b/app/routes/legal.py
@@ -1,0 +1,17 @@
+"""Routes for legal information pages."""
+
+from flask import Blueprint, render_template
+
+bp = Blueprint('legal', __name__)
+
+
+@bp.route('/impressum')
+def impressum():
+    """Display the Impressum page."""
+    return render_template('legal/impressum.html')
+
+
+@bp.route('/datenschutz')
+def datenschutz():
+    """Display the Datenschutzerklärung page."""
+    return render_template('legal/datenschutz.html')


### PR DESCRIPTION
## Summary
- add new blueprint exposing `/impressum` and `/datenschutz` pages
- register legal blueprint in application factory

## Testing
- `python -m py_compile app/routes/legal.py app/__init__.py`
- `PYTHONPATH=. pytest -q` *(fails: sqlite3.OperationalError: no such function: RecoverGeometryColumn)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ee9ab6d88320b10b725f1a13b273