### PR TITLE
Restrict chat actions to authenticated users

### DIFF
--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -13,6 +13,7 @@
 <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 <script>
   const roomId = {{ room_id }};
+  const userId = {{ current_user.id }};
   const socket = io();
   socket.emit('join_room', {room: roomId});
 
@@ -36,7 +37,7 @@
     e.preventDefault();
     const text = document.getElementById('message-input').value;
     if (text) {
-      socket.emit('send_message', {room_id: roomId, user_id: 1, message: text});
+      socket.emit('send_message', {room_id: roomId, user_id: userId, message: text});
       document.getElementById('message-input').value = '';
     }
   });


### PR DESCRIPTION
## Summary
- Require login on chat API routes and use `current_user.id` for message creation
- Expose current user's ID in chat room template for message sending
- Ensure Socket.IO message events only accept messages from authenticated users

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'shapely')*
- `pip install Shapely==2.0.1 2>&1 | tail -n 20` *(fails: Could not find geos-config executable / geos_c.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0cbf8808320b8bbea9d4409eb1e