### PR TITLE
Add production config and document selection via FLASK_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,27 @@ Socket.IO-enabled Gunicorn server without enabling the Flask debugger:
 The script honours environment variables defined in a local `.env` file and
 runs `flask db upgrade` before delegating to Gunicorn.
 
+## Configuration
+
+The application picks its configuration class based on the `FLASK_CONFIG`
+environment variable. When the variable is not set the default development
+configuration is used. Set `FLASK_CONFIG=production` (or provide the full
+import path to a configuration class) to activate the production settings.
+
+The production configuration requires two environment variables to be present
+before the app starts:
+
+* `SECRET_KEY` – the Flask secret key used to sign session cookies.
+* `DATABASE_URL` – SQLAlchemy connection string for the production database.
+
+Example invocation:
+
+```bash
+export SECRET_KEY='change-me'
+export DATABASE_URL='postgresql://user:password@host:5432/dbname'
+export FLASK_CONFIG=production
+flask --app run.py run
+```
+
 The project is licensed under the MIT License. See [LICENSE](LICENSE) for
 details.

--- a/app/config.py
+++ b/app/config.py
@@ -38,3 +38,49 @@ class Config:
 
     ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL", "admin@example.com")
     ADMIN_NAME = "Jonas Hellinghausen"
+
+    @classmethod
+    def init_app(cls, app):  # pragma: no cover - default hook for subclasses
+        """Hook for subclasses to perform additional validation."""
+
+
+class ProductionConfig(Config):
+    """Configuration for production deployments.
+
+    ``SECRET_KEY`` and ``DATABASE_URL`` must be provided via environment
+    variables to avoid insecure defaults when running in production.
+    """
+
+    SECRET_KEY = None
+    SQLALCHEMY_DATABASE_URI = None
+    DEBUG = False
+
+    ENV_VAR_MAPPING = {
+        "SECRET_KEY": "SECRET_KEY",
+        "SQLALCHEMY_DATABASE_URI": "DATABASE_URL",
+    }
+
+    @classmethod
+    def init_app(cls, app):
+        super().init_app(app)
+
+        missing = []
+        for config_key, env_var in cls.ENV_VAR_MAPPING.items():
+            value = os.environ.get(env_var)
+            if value:
+                app.config[config_key] = value
+            else:
+                missing.append(env_var)
+
+        if missing:
+            missing_values = ", ".join(missing)
+            raise RuntimeError(
+                "ProductionConfig requires the following environment variables to be set: "
+                f"{missing_values}"
+            )
+
+
+CONFIG_MAPPINGS = {
+    "default": Config,
+    "production": ProductionConfig,
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app import create_app
+from app.config import Config, ProductionConfig
+
+
+class CustomConfig(Config):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+
+
+def test_production_config_requires_env(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError):
+        create_app(ProductionConfig)
+
+
+def test_production_config_loads_env(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "super-secret")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    app = create_app(ProductionConfig)
+
+    assert app.config["SECRET_KEY"] == "super-secret"
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"
+
+
+def test_flask_config_env_missing_variables(monkeypatch):
+    monkeypatch.setenv("FLASK_CONFIG", "production")
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    with pytest.raises(RuntimeError):
+        create_app()
+
+
+def test_create_app_uses_flask_config(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "prod-secret")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("FLASK_CONFIG", "production")
+
+    app = create_app()
+
+    assert app.config["SECRET_KEY"] == "prod-secret"
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"
+
+    monkeypatch.setenv("FLASK_CONFIG", "tests.test_config.CustomConfig")
+
+    app = create_app()
+
+    assert app.config["TESTING"] is True
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"


### PR DESCRIPTION
## Summary
- add a ProductionConfig that validates the presence of SECRET_KEY and DATABASE_URL
- allow the application factory to resolve configuration classes from the FLASK_CONFIG environment variable or a dotted import path
- document configuration selection and required production secrets in the README and cover the behaviour with dedicated tests
- ensure pytest finds the local application package and make the SpatiaLite extension optional during SQLite setup

## Testing
- pytest tests/test_config.py -vv
- pytest *(fails: requires SpatiaLite extension functions such as RecoverGeometryColumn)*

------
https://chatgpt.com/codex/tasks/task_e_68c904a23e308320b9d6f69b149ff76f